### PR TITLE
Fix UB/unsoundness in slice_to_long

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 
 use std::io;
 use std::io::Write;
-use std::mem;
+use std::ptr;
 use crc_table::CRC64_TAB;
 mod crc_table;
 
@@ -114,8 +114,7 @@ macro_rules! slice_to_long {
     ($curVec:expr) => {
         {
             unsafe {
-                let (tmp, _) : (*const u64, usize) = mem::transmute(&$curVec);
-                *tmp
+                ptr::read_unaligned($curVec.as_ptr().cast::<u64>())
             }
         }
     }


### PR DESCRIPTION
There are two problems with the previous impl:

1. It assumes the layout of slices. The layout of slices is not guaranteed, and may change at any time.

2. It assumes that the pointer being read from is correctly aligned for reads of a u64. This is not true in general, and not true in the tests (this can be observed with `cargo miri test`). The usual algorithm is to do smaller reads until an alignment boundary is reached, but just calling read_unaligned is simpler and unlikely to be much slower on platforms like x86_64.